### PR TITLE
Rework some grid stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,16 +28,14 @@ All the code you need is simple and familiar. A parent container class contains 
 </div>
 ```
 
-To control the sizing behavior, you can apply a breakpoint to your column classes (EX: `.col-6-sm`).
-Not specifying a breakpoint is equal to using the medium breakpoint (EX: `.col-6-md`).
+To control the sizing behavior, you can apply a breakpoint to your column classes (EX: `.col-6-sm`, `.col-3-xlg`).
+If you don't specify a breakpoint, the column will apply to all screen sizes.
+You may also us `col` to have the columns automatically adjust their size. When using `col`, you may have any arbitrary number of columns.
 
 ### Utility
 
-- `left`: Aligns content to the left.
-- `right`: Aligns content to the right.
-- `center`: Centers content.
-- `justify`: Applies the "justify" content alignment.
-- `hidden-sm`
+Simple Grid+ provides placement classes much like bootstrap. These include margin, padding, and gap.
+Examples: `gap-3`, `m-2`, `p-3`, `mr-2`.
 
 ### Breakpoints
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Simple Grid+
 
-Lightweight (~2KB uncompressed) and responsive CSS grid & utility components for easier front-end development. Optionally includes typography as well.
+Lightweight (less than 5KB uncompressed) and responsive CSS grid & utility components for easier front-end development.
 
 Based on [Simple Grid](https://github.com/zachacole/Simple-Grid) originally created by Zach Cole.
 
@@ -48,6 +48,7 @@ Examples: `gap-3`, `m-2`, `p-3`, `mr-2`.
 ### Typography
 
 Note: typography is not included in the default Simple Gride+ CSS files and must be included seperately.
+It may also be removed or seperated from the Simple Grid+ project in the future.
 
 - `font-light`
 - `font-regular`

--- a/README.md
+++ b/README.md
@@ -41,9 +41,11 @@ Not specifying a breakpoint is equal to using the medium breakpoint (EX: `.col-6
 
 ### Breakpoints
 
-- `sm`: 33.75em; // 540px
-- `md`: 45em; // 720px
-- `lg`: 60em; // 960px
+- `xsm`: Anything smaller than the `sm` breakpoint.
+- `sm`: `33.75em` (540px).
+- `md`: `45em` (720px).
+- `lg`: `60em` (960px).
+- `xlg`: `75em` (1200px).
 
 ### Typography
 

--- a/sass/_grid.scss
+++ b/sass/_grid.scss
@@ -1,77 +1,59 @@
 @use "sass:math";
 
+// Function for generating column styles
+@function generate-width($columns, $i) {
+  @return percentage(math.div($i, $columns));
+}
+
+// Mixin for generating column styles
+@mixin generate-columns($prefix, $breakpoint: null) {
+  @for $i from 1 through $columns {
+    .#{$prefix}-#{$i}#{$breakpoint} {
+      flex: 0 0 generate-width($columns, $i);
+      max-width: generate-width($columns, $i);
+    }
+  }
+}
+
 /* Grid */
 .container {
-  width: 90%;
   margin-left: auto;
   margin-right: auto;
-
-  @media only screen and (min-width: $breakpoint-small) {
-    width: 80%;
-  }
-
-  @media only screen and (min-width: $breakpoint-large) {
-    width: 75%;
-    max-width: 60rem;
-  }
+  display: block;
 }
 
 .row {
+  margin: 0;
+  padding: 0;
   position: relative;
   width: 100%;
+  display: flex;
+  flex-wrap: wrap;
 }
 
 .row [class^="col-"] {
-  float: left;
-  margin: 0.5rem math.div($gutter, 2);
-  min-height: 0.125rem;
-}
-
-.row::after {
-  content: "";
-  display: table;
-  clear: both;
+  margin: 0;
+  padding: 0;
+  min-height: 0.125em;
+  box-sizing: border-box;
 }
 
 /* Columns for all screen sizes */
-@for $i from 1 through $columns {
-  .col-#{$i} {
-    width: calc($width / $columns * $i - $gutter);
-  }
-}
+@include generate-columns("col");
 
-/* Columns for the small breakpoint */
+/* Columns for different breakpoints */
 @media only screen and (min-width: $breakpoint-small) {
-  @for $i from 1 through $columns {
-    .col-#{$i}-sm {
-      width: calc($width / $columns * $i - $gutter);
-    }
-  }
+  @include generate-columns("col", "-sm");
 }
 
-/* Columns for the medium breakpoint */
 @media only screen and (min-width: $breakpoint-med) {
-  @for $i from 1 through $columns {
-    .col-#{$i}-md {
-      width: calc($width / $columns * $i - $gutter);
-    }
-  }
+  @include generate-columns("col", "-md");
 }
 
-/* Columns for the large breakpoint */
 @media only screen and (min-width: $breakpoint-large) {
-  @for $i from 1 through $columns {
-    .col-#{$i}-lg {
-      width: calc($width / $columns * $i - $gutter);
-    }
-  }
+  @include generate-columns("col", "-lg");
 }
 
-/* Columns for the extra large breakpoint */
 @media only screen and (min-width: $breakpoint-xlarge) {
-  @for $i from 1 through $columns {
-    .col-#{$i}-xlg {
-      width: calc($width / $columns * $i - $gutter);
-    }
-  }
+  @include generate-columns("col", "-xlg");
 }

--- a/sass/_grid.scss
+++ b/sass/_grid.scss
@@ -33,22 +33,45 @@
   clear: both;
 }
 
+/* Columns for all screen sizes */
 @for $i from 1 through $columns {
   .col-#{$i} {
-    width: $width;
+    width: calc($width / $columns * $i - $gutter);
   }
 }
 
+/* Columns for the small breakpoint */
+@media only screen and (min-width: $breakpoint-small) {
+  @for $i from 1 through $columns {
+    .col-#{$i}-sm {
+      width: calc($width / $columns * $i - $gutter);
+    }
+  }
+}
+
+/* Columns for the medium breakpoint */
 @media only screen and (min-width: $breakpoint-med) {
   @for $i from 1 through $columns {
-
-    .col-#{$i},
     .col-#{$i}-md {
       width: calc($width / $columns * $i - $gutter);
     }
+  }
+}
 
-    .hidden-sm {
-      display: block;
+/* Columns for the large breakpoint */
+@media only screen and (min-width: $breakpoint-large) {
+  @for $i from 1 through $columns {
+    .col-#{$i}-lg {
+      width: calc($width / $columns * $i - $gutter);
+    }
+  }
+}
+
+/* Columns for the extra large breakpoint */
+@media only screen and (min-width: $breakpoint-xlarge) {
+  @for $i from 1 through $columns {
+    .col-#{$i}-xlg {
+      width: calc($width / $columns * $i - $gutter);
     }
   }
 }

--- a/sass/_grid.scss
+++ b/sass/_grid.scss
@@ -10,7 +10,6 @@
   @for $i from 1 through $columns {
     .#{$prefix}-#{$i}#{$breakpoint} {
       flex: 0 0 generate-width($columns, $i);
-      max-width: generate-width($columns, $i);
     }
   }
 }
@@ -32,8 +31,6 @@
 }
 
 .row [class^="col-"] {
-  margin: 0;
-  padding: 0;
   min-height: 0.125em;
   box-sizing: border-box;
 }

--- a/sass/_grid.scss
+++ b/sass/_grid.scss
@@ -38,6 +38,10 @@
   box-sizing: border-box;
 }
 
+.col {
+  flex: 1;
+}
+
 /* Columns for all screen sizes */
 @include generate-columns("col");
 

--- a/sass/_utility.scss
+++ b/sass/_utility.scss
@@ -16,7 +16,3 @@
 .justify {
     text-align: justify;
 }
-
-.hidden-sm {
-    display: none;
-}

--- a/sass/_utility.scss
+++ b/sass/_utility.scss
@@ -1,18 +1,68 @@
 /* Utility */
-.left {
-    text-align: left;
+// Gap Classes
+$gap-values: (
+    0: 0,
+    1: 0.25rem,
+    2: 0.5rem,
+    3: 1rem,
+    4: 1.5rem,
+    5: 3rem
+);
+
+@each $key, $value in $gap-values {
+    .gap-#{$key} {
+        gap: $value;
+    }
 }
 
-.right {
-    text-align: right;
-}
+// Margin and Padding Classes
+$spacing-values: (
+    0: 0,
+    1: 0.25rem,
+    2: 0.5rem,
+    3: 1rem,
+    4: 1.5rem,
+    5: 3rem
+);
 
-.center {
-    text-align: center;
-    margin-left: auto;
-    margin-right: auto;
-}
+@each $key, $value in $spacing-values {
+    .m-#{$key} {
+        margin: $value;
+    }
 
-.justify {
-    text-align: justify;
+    .mt-#{$key} {
+        margin-top: $value;
+    }
+
+    .mb-#{$key} {
+        margin-bottom: $value;
+    }
+
+    .ml-#{$key} {
+        margin-left: $value;
+    }
+
+    .mr-#{$key} {
+        margin-right: $value;
+    }
+
+    .p-#{$key} {
+        padding: $value;
+    }
+
+    .pt-#{$key} {
+        padding-top: $value;
+    }
+
+    .pb-#{$key} {
+        padding-bottom: $value;
+    }
+
+    .pl-#{$key} {
+        padding-left: $value;
+    }
+
+    .pr-#{$key} {
+        padding-right: $value;
+    }
 }

--- a/sass/_variables.scss
+++ b/sass/_variables.scss
@@ -4,6 +4,7 @@ $gutter: 1.5%;
 $breakpoint-small: 33.75em; // 540px
 $breakpoint-med: 45em; // 720px
 $breakpoint-large: 60em; // 960px
+$breakpoint-xlarge: 75em; // 1200px
 $columns: 12;
 
 /* Typography */

--- a/sass/_variables.scss
+++ b/sass/_variables.scss
@@ -1,6 +1,4 @@
 /* Grid / Utility */
-$width: 96%;
-$gutter: 1.5%;
 $breakpoint-small: 33.75em; // 540px
 $breakpoint-med: 45em; // 720px
 $breakpoint-large: 60em; // 960px


### PR DESCRIPTION
- Changed how the breakpoints work. It now behaves like bootstrap.
- Added in more breakpoints
- Changed to flex display
- To make calculation easy, removed all padding and margin for the columns themselves. Padding or margin can be applied to items within the column instead.
- All new `col` tag to enable automatic column sizing.